### PR TITLE
Point at the new endpoint for initial Overpass state

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -8,7 +8,7 @@ var osmStream = (function osmMinutely() {
 
     // presets
     var baseUrl = 'https://overpass-api.de/',
-        minuteStatePath = 'augmented_diffs/state.txt',
+        minuteStatePath = 'api/augmented_diff_status',
         changePath = 'api/augmented_diff?';
 
     function minuteStateUrl() {

--- a/osmstream.js
+++ b/osmstream.js
@@ -8,7 +8,7 @@ var osmStream = (function osmMinutely() {
 
     // presets
     var baseUrl = 'https://overpass-api.de/',
-        minuteStatePath = 'augmented_diffs/state.txt',
+        minuteStatePath = 'api/augmented_diff_status',
         changePath = 'api/augmented_diff?';
 
     function minuteStateUrl() {


### PR DESCRIPTION
The state.txt isn't updated anymore, according to [this helpfully silent](http://wiki.openstreetmap.org/w/index.php?title=Overpass_API/Augmented_Diffs&diff=prev&oldid=1054288) wiki edit on the augmented diffs wiki page.

This change points us to the correct endpoint.
